### PR TITLE
Use rj_schema gem for response body json validation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -9,6 +9,7 @@ PATH
       json_schemer (~> 0.2.16)
       multi_json (~> 1.14)
       rack (~> 2.2)
+      rj_schema (~> 1.0, >= 1.0.4)
 
 GEM
   remote: https://rubygems.org/
@@ -63,6 +64,7 @@ GEM
     rake (13.0.6)
     regexp_parser (2.7.0)
     rexml (3.2.5)
+    rj_schema (1.0.4)
     rspec (3.12.0)
       rspec-core (~> 3.12.0)
       rspec-expectations (~> 3.12.0)

--- a/openapi_first.gemspec
+++ b/openapi_first.gemspec
@@ -41,6 +41,7 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'json_schemer', '~> 0.2.16'
   spec.add_runtime_dependency 'multi_json', '~> 1.14'
   spec.add_runtime_dependency 'rack', '~> 2.2'
+  spec.add_runtime_dependency 'rj_schema', '~> 1.0', '>= 1.0.4'
 
   spec.add_development_dependency 'bundler', '~> 2'
   spec.add_development_dependency 'rack-test', '~> 1'

--- a/spec/data/nullable.yaml
+++ b/spec/data/nullable.yaml
@@ -30,6 +30,7 @@ components:
         - name
       properties:
         name:
-          type: string
-          nullable: true
+          oneOf:
+            - type: string
+            - type: 'null'
 

--- a/spec/response_validation_spec.rb
+++ b/spec/response_validation_spec.rb
@@ -156,10 +156,15 @@ RSpec.describe OpenapiFirst::ResponseValidation do
     end
 
     specify do
-      message = [
-        "property '/0' is missing required keys: id",
-        "property '/1/id' is not of type: integer"
-      ].join(', ')
+      message = "Error Name: required\n" \
+                "Message: Object is missing the following members required by the schema: 'id'.\n" \
+                "Instance: #/0\n" \
+                "Schema: #/items\n\n" \
+                "Error Name: type\n" \
+                "Message: Property has a type 'string' that is not in the following list: 'integer'.\n" \
+                "Instance: #/1/id\n" \
+                "Schema: #/items/properties/id\n\n"
+
       expect do
         get '/pets/42'
       end.to raise_error OpenapiFirst::ResponseBodyInvalidError, message
@@ -175,7 +180,8 @@ RSpec.describe OpenapiFirst::ResponseValidation do
         json_dump({ name: 'hans', password: 'admin' })
       end
 
-      it 'raises an error' do
+      # This test would fail as rj_schema does not support writeOnly
+      xit 'raises an error' do
         message = 'Write-only field appears in response: /password'
         expect do
           post '/test', json_dump({ name: 'hans', password: 'admin' })
@@ -192,7 +198,9 @@ RSpec.describe OpenapiFirst::ResponseValidation do
     end
 
     it 'raises an error if the readOnly field is missing' do
-      message = 'root is missing required keys: id'
+      message = "Error Name: required\n" \
+                "Message: Object is missing the following members required by the schema: 'id'.\n" \
+                "Instance: #\nSchema: #\n\n"
       expect do
         get '/test/42'
       end.to raise_error OpenapiFirst::ResponseBodyInvalidError, message
@@ -219,7 +227,9 @@ RSpec.describe OpenapiFirst::ResponseValidation do
       end
 
       it 'raises an error' do
-        message = 'root is missing required keys: name'
+        message = "Error Name: required\n" \
+                  "Message: Object is missing the following members required by the schema: 'name'.\n" \
+                  "Instance: #\nSchema: #\n\n"
         expect do
           get '/test'
         end.to raise_error OpenapiFirst::ResponseBodyInvalidError, message


### PR DESCRIPTION
JSON body response validation is slow for responses with big payloads. 
This PR substitutes the json_schemer with rj_schema (native C implementation) for response validation ONLY.

This comes with some downsides - nullable and writeOnly (not used by us) are not supported, so some of the openAPI definitions have to be modified.