### PR TITLE
Add null type for schemas with `nullable` types while loading the schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,14 @@
 
 ## Unreleased
 
+## 1.1.0
+- Add null type for schemas with `nullable` types while loading the schema.
+
 ## 1.0.0
 - Use rj_schema gem for response body json validation
 
   BREAKING CHANGE: After this change validating against schemas with `nullable` will not work correctly.
-  The definitions should be modified to use oneOf element with a childred "null" and the original type to achive the same effect. 
+  The definitions should be modified to use oneOf element with a childred "null" and the original type to achieve the same effect. 
 
 ## 0.21.0
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    openapi_first (1.0.0)
+    openapi_first (1.1.0)
       deep_merge (>= 1.2.1)
       hanami-router (~> 2.0.0)
       hanami-utils (~> 2.0.0)

--- a/lib/openapi_first/version.rb
+++ b/lib/openapi_first/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module OpenapiFirst
-  VERSION = '1.0.0'
+  VERSION = '1.1.0'
 end

--- a/spec/data/nullable.yaml
+++ b/spec/data/nullable.yaml
@@ -30,7 +30,6 @@ components:
         - name
       properties:
         name:
-          oneOf:
-            - type: string
-            - type: 'null'
+          type: string
+          nullable: true
 


### PR DESCRIPTION
* needed because rj_schema does not recognize the `nullable` attribute
* This will bring back the possibility to use schemas with `nullable: true` attributes.

https://kanbanzone.io/b/YA2t2Uox/c/1079-Overhaul-OpenAPI-response-validation