### PR TITLE
Add XML response validation support

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,3 +12,12 @@ Metrics/BlockLength:
     - "*.gemspec"
 Metrics/MethodLength:
   Max: 20
+
+Metrics/AbcSize:
+  Max: 30
+
+Metrics/CyclomaticComplexity:
+  Max: 13
+
+Metrics/PerceivedComplexity:
+  Max: 14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+## 1.2.0
+- Add support for xml response validation
+
 ## 1.1.0
 - Add null type for schemas with `nullable` types while loading the schema.
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,8 @@
 PATH
   remote: .
   specs:
-    openapi_first (1.1.0)
+    openapi_first (1.2.0)
+      activesupport (>= 7.1)
       deep_merge (>= 1.2.1)
       hanami-router (~> 2.0.0)
       hanami-utils (~> 2.0.0)
@@ -14,11 +15,29 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
+    activesupport (7.1.6)
+      base64
+      benchmark (>= 0.3)
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      connection_pool (>= 2.2.5)
+      drb
+      i18n (>= 1.6, < 2)
+      logger (>= 1.4.2)
+      minitest (>= 5.1)
+      mutex_m
+      securerandom (>= 0.3)
+      tzinfo (~> 2.0)
     ast (2.4.2)
+    base64 (0.3.0)
+    benchmark (0.5.0)
+    bigdecimal (4.0.1)
     coderay (1.1.3)
     concurrent-ruby (1.2.2)
+    connection_pool (2.5.5)
     deep_merge (1.2.2)
     diff-lcs (1.5.0)
+    drb (2.2.3)
     dry-core (1.0.0)
       concurrent-ruby (~> 1.0)
       zeitwerk (~> 2.6)
@@ -36,6 +55,8 @@ GEM
       dry-core (~> 1.0, < 2)
       dry-transformer (~> 1.0, < 2)
     hansi (0.2.1)
+    i18n (1.14.8)
+      concurrent-ruby (~> 1.0)
     json (2.6.3)
     json_refs (0.1.8)
       hana
@@ -44,13 +65,16 @@ GEM
       hana (~> 1.3)
       regexp_parser (~> 2.0)
       uri_template (~> 0.7)
+    logger (1.7.0)
     method_source (1.0.0)
+    minitest (5.27.0)
     multi_json (1.15.0)
     mustermann (3.0.0)
       ruby2_keywords (~> 0.0.1)
     mustermann-contrib (3.0.0)
       hansi (~> 0.2.0)
       mustermann (= 3.0.0)
+    mutex_m (0.3.0)
     parallel (1.22.1)
     parser (3.2.1.0)
       ast (~> 2.4.1)
@@ -92,6 +116,9 @@ GEM
       parser (>= 3.2.1.0)
     ruby-progressbar (1.11.0)
     ruby2_keywords (0.0.5)
+    securerandom (0.4.1)
+    tzinfo (2.0.6)
+      concurrent-ruby (~> 1.0)
     unicode-display_width (2.4.2)
     uri_template (0.7.0)
     zeitwerk (2.6.12)

--- a/lib/openapi_first/body_parser_middleware.rb
+++ b/lib/openapi_first/body_parser_middleware.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
+require 'active_support/isolated_execution_state'
+require 'active_support/xml_mini'
+require 'active_support/core_ext/hash/conversions'
 require 'multi_json'
+require_relative 'xml_coercion'
 
 module OpenapiFirst
   class BodyParserMiddleware
@@ -37,6 +41,7 @@ module OpenapiFirst
       return if body.empty?
 
       return MultiJson.load(body) if request.media_type =~ (/json/i) && (request.media_type =~ /json/i)
+      return Hash.from_xml(body) if XmlCoercion.xml_content_type?(request.content_type)
       return request.POST if request.form_data?
 
       body

--- a/lib/openapi_first/body_parser_middleware.rb
+++ b/lib/openapi_first/body_parser_middleware.rb
@@ -45,7 +45,7 @@ module OpenapiFirst
       return request.POST if request.form_data?
 
       body
-    rescue MultiJson::ParseError => e
+    rescue MultiJson::ParseError, REXML::ParseException, Nokogiri::XML::SyntaxError => e
       raise BodyParsingError, e
     end
 

--- a/lib/openapi_first/request_validation.rb
+++ b/lib/openapi_first/request_validation.rb
@@ -5,6 +5,8 @@ require 'multi_json'
 require_relative 'inbox'
 require_relative 'use_router'
 require_relative 'validation_format'
+require_relative 'xml_coercion'
+require_relative 'type_coercion'
 
 module OpenapiFirst
   class RequestValidation # rubocop:disable Metrics/ClassLength
@@ -15,7 +17,7 @@ module OpenapiFirst
       @raise = options.fetch(:raise_error, false)
     end
 
-    def call(env) # rubocop:disable Metrics/AbcSize
+    def call(env)
       operation = env[OPERATION]
       return @app.call(env) unless operation
 
@@ -54,6 +56,11 @@ module OpenapiFirst
 
       schema = operation&.request_body_schema(request.content_type)
       return unless schema
+
+      # Convert XML string values to proper types based on schema
+      if XmlCoercion.xml_content_type?(request.content_type) && body.is_a?(Hash)
+        body = XmlCoercion.coerce_types(body, schema.raw_schema)
+      end
 
       errors = schema.validate(body)
       throw_error(400, serialize_request_body_errors(errors)) if errors.any?
@@ -118,13 +125,13 @@ module OpenapiFirst
     def filtered_params(json_schema, params)
       json_schema['properties']
         .each_with_object({}) do |key_value, result|
-          parameter_name = key_value[0].to_sym
-          schema = key_value[1]
-          next unless params.key?(parameter_name)
+        parameter_name = key_value[0].to_sym
+        schema = key_value[1]
+        next unless params.key?(parameter_name)
 
-          value = params[parameter_name]
-          result[parameter_name] = parse_parameter(value, schema)
-        end
+        value = params[parameter_name]
+        result[parameter_name] = parse_parameter(value, schema)
+      end
     end
 
     def serialize_query_parameter_errors(validation_errors)
@@ -141,7 +148,7 @@ module OpenapiFirst
 
       return parse_array_parameter(value, schema) if schema['type'] == 'array'
 
-      parse_simple_value(value, schema)
+      TypeCoercion.coerce_value(value, schema)
     end
 
     def parse_array_parameter(value, schema)
@@ -150,26 +157,7 @@ module OpenapiFirst
       array = value.is_a?(Array) ? value : value.split(',')
       return array unless schema['items']
 
-      array.map! { |e| parse_simple_value(e, schema['items']) }
-    end
-
-    def parse_simple_value(value, schema)
-      return to_boolean(value) if schema['type'] == 'boolean'
-
-      begin
-        return Integer(value, 10) if schema['type'] == 'integer'
-        return Float(value) if schema['type'] == 'number'
-      rescue ArgumentError
-        value
-      end
-      value
-    end
-
-    def to_boolean(value)
-      return true if value == 'true'
-      return false if value == 'false'
-
-      value
+      array.map! { |e| TypeCoercion.coerce_value(e, schema['items']) }
     end
   end
 end

--- a/lib/openapi_first/response_validation.rb
+++ b/lib/openapi_first/response_validation.rb
@@ -7,6 +7,7 @@ require 'multi_json'
 require 'rj_schema'
 require_relative 'use_router'
 require_relative 'validation_format'
+require_relative 'xml_coercion'
 
 module OpenapiFirst
   class ResponseValidation
@@ -40,18 +41,13 @@ module OpenapiFirst
       operation.response_for(status)
     end
 
-    def xml_content?(content_type)
-      media_type = content_type.split(';').first.strip
-      %w[application/xml text/xml].include?(media_type)
-    end
-
     def validate_response_body(schema, response, content_type)
-      full_body = +''
-      response.each { |chunk| full_body << chunk }
+      full_body = response.to_a.join
       data = if full_body.empty?
                {}
-             elsif xml_content?(content_type)
-               Hash.from_xml(full_body)
+             elsif XmlCoercion.xml_content_type?(content_type)
+               parsed = Hash.from_xml(full_body)
+               XmlCoercion.coerce_types(parsed, schema.raw_schema)
              else
                load_json(full_body)
              end

--- a/lib/openapi_first/response_validation.rb
+++ b/lib/openapi_first/response_validation.rb
@@ -42,7 +42,8 @@ module OpenapiFirst
     end
 
     def validate_response_body(schema, response, content_type)
-      full_body = response.to_a.join
+      full_body = +''
+      response.each { |chunk| full_body << chunk }
       data = if full_body.empty?
                {}
              elsif XmlCoercion.xml_content_type?(content_type)

--- a/lib/openapi_first/response_validation.rb
+++ b/lib/openapi_first/response_validation.rb
@@ -1,5 +1,8 @@
 # frozen_string_literal: true
 
+require 'active_support/isolated_execution_state'
+require 'active_support/xml_mini'
+require 'active_support/core_ext/hash/conversions'
 require 'multi_json'
 require 'rj_schema'
 require_relative 'use_router'
@@ -28,7 +31,7 @@ module OpenapiFirst
 
       content_type = headers[Rack::CONTENT_TYPE]
       response_schema = operation.response_schema_for(status, content_type)
-      validate_response_body(response_schema, body) if response_schema
+      validate_response_body(response_schema, body, content_type) if response_schema
     end
 
     private
@@ -37,10 +40,21 @@ module OpenapiFirst
       operation.response_for(status)
     end
 
-    def validate_response_body(schema, response)
+    def xml_content?(content_type)
+      media_type = content_type.split(';').first.strip
+      %w[application/xml text/xml].include?(media_type)
+    end
+
+    def validate_response_body(schema, response, content_type)
       full_body = +''
       response.each { |chunk| full_body << chunk }
-      data = full_body.empty? ? {} : load_json(full_body)
+      data = if full_body.empty?
+               {}
+             elsif xml_content?(content_type)
+               Hash.from_xml(full_body)
+             else
+               load_json(full_body)
+             end
 
       error = RjSchema::Validator.new.validate(
         schema.raw_schema, data, continue_on_error: true, machine_errors: false, human_errors: true

--- a/lib/openapi_first/router.rb
+++ b/lib/openapi_first/router.rb
@@ -27,6 +27,7 @@ module OpenapiFirst
     def call(env)
       env[OPERATION] = nil
       response = call_router(env)
+
       if env[OPERATION].nil?
         return @parent_app.call(env) if @parent_app # This should only happen if used via OpenapiFirst.middleware
 
@@ -36,6 +37,8 @@ module OpenapiFirst
       end
 
       response
+    rescue BodyParsingError => e
+      handle_body_parsing_error(exception: e, env: env)
     end
 
     ORIGINAL_PATH = 'openapi_first.path_info'
@@ -56,14 +59,12 @@ module OpenapiFirst
       env[ORIGINAL_PATH] = env[Rack::PATH_INFO]
       env[Rack::PATH_INFO] = Rack::Request.new(env).path
       @router.call(env)
-    rescue BodyParsingError => e
-      handle_body_parsing_error(e)
     ensure
       env[Rack::PATH_INFO] = env.delete(ORIGINAL_PATH) if env[ORIGINAL_PATH]
     end
 
-    def handle_body_parsing_error(exception)
-      err = { title: 'Failed to parse body as application/json', status: '400' }
+    def handle_body_parsing_error(exception:, env:)
+      err = { title: "Failed to parse body as #{env['CONTENT_TYPE']}", status: '400' }
       err[:detail] = exception.cause unless ENV['RACK_ENV'] == 'production'
       errors = [err]
       raise RequestInvalidError, errors if @raise
@@ -86,9 +87,8 @@ module OpenapiFirst
           )
         end
       end
-      raise_error = @raise
       Rack::Builder.app do
-        use BodyParserMiddleware, raise_error: raise_error
+        use BodyParserMiddleware, raise_error: true
         run router
       end
     end

--- a/lib/openapi_first/type_coercion.rb
+++ b/lib/openapi_first/type_coercion.rb
@@ -16,7 +16,7 @@ module OpenapiFirst
       value
     end
 
-    def to_boolean(value)
+    private_class_method def to_boolean(value)
       return true if value == 'true'
       return false if value == 'false'
 

--- a/lib/openapi_first/type_coercion.rb
+++ b/lib/openapi_first/type_coercion.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+module OpenapiFirst
+  module TypeCoercion
+    module_function
+
+    def coerce_value(value, schema)
+      return to_boolean(value) if schema['type'] == 'boolean'
+
+      begin
+        return Integer(value, 10) if schema['type'] == 'integer'
+        return Float(value) if schema['type'] == 'number'
+      rescue ArgumentError
+        value
+      end
+      value
+    end
+
+    def to_boolean(value)
+      return true if value == 'true'
+      return false if value == 'false'
+
+      value
+    end
+  end
+end

--- a/lib/openapi_first/validation_format.rb
+++ b/lib/openapi_first/validation_format.rb
@@ -6,8 +6,6 @@ module OpenapiFirst
 
     # rubocop:disable Metrics/MethodLength
     # rubocop:disable Metrics/AbcSize
-    # rubocop:disable Metrics/CyclomaticComplexity
-    # rubocop:disable Metrics/PerceivedComplexity
     def self.error_details(error)
       if error['type'] == 'pattern'
         {
@@ -49,7 +47,5 @@ module OpenapiFirst
     end
     # rubocop:enable Metrics/MethodLength
     # rubocop:enable Metrics/AbcSize
-    # rubocop:enable Metrics/CyclomaticComplexity
-    # rubocop:enable Metrics/PerceivedComplexity
   end
 end

--- a/lib/openapi_first/version.rb
+++ b/lib/openapi_first/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module OpenapiFirst
-  VERSION = '1.1.0'
+  VERSION = '1.2.0'
 end

--- a/lib/openapi_first/xml_coercion.rb
+++ b/lib/openapi_first/xml_coercion.rb
@@ -23,7 +23,7 @@ module OpenapiFirst
 
         # Check if this property has oneOf/anyOf/allOf
         result[key] = if property_schema['oneOf'] || property_schema['anyOf'] || property_schema['allOf']
-                        coerce_with_one_of(value, property_schema)
+                        coerce_with_combined_schemas(value, property_schema)
                       elsif property_schema['properties'] && value.is_a?(Hash)
                         # Nested object - recurse
                         coerce_types(value, property_schema)
@@ -40,18 +40,26 @@ module OpenapiFirst
       end.merge(data.except(*schema['properties'].keys))
     end
 
-    private_class_method def coerce_with_one_of(value, schema)
-      schemas = schema['oneOf'] || schema['anyOf'] || schema['allOf']
+    private_class_method def coerce_with_combined_schemas(value, schema)
+      # Special handling for allOf - merge all schemas together
+      if schema['allOf']
+        schemas = schema['allOf']
+        merged_properties = schemas.each_with_object({}) do |s, props|
+          props.merge!(s['properties']) if s['properties']
+        end
+        merged_schema = { 'type' => 'object', 'properties' => merged_properties }
+        return coerce_item(value, merged_schema)
+      end
 
-      # For Hash (single item), try the first schema (should be the object schema)
-      # For Array, try the second schema (should be the array schema)
+      # For oneOf/anyOf, pick the appropriate schema based on value type
+      schemas = schema['oneOf'] || schema['anyOf']
+
       case value
       when Array
         array_schema = schemas.find { |s| s['type'] == 'array' }
         return coerce_array(value, array_schema) if array_schema
       when Hash
         object_schema = schemas.find { |s| s['type'] != 'array' }
-        # Need to resolve $ref here - for now just try to coerce
         return coerce_item(value, object_schema) if object_schema
       end
 

--- a/lib/openapi_first/xml_coercion.rb
+++ b/lib/openapi_first/xml_coercion.rb
@@ -1,0 +1,77 @@
+# frozen_string_literal: true
+
+require_relative 'type_coercion'
+
+module OpenapiFirst
+  module XmlCoercion
+    module_function
+
+    def xml_content_type?(content_type)
+      return false unless content_type
+
+      media_type = content_type.split(';').first.strip
+      %w[application/xml text/xml].include?(media_type)
+    end
+
+    def coerce_types(data, schema)
+      return data unless schema['properties']
+
+      schema['properties'].each_with_object({}) do |(key, property_schema), result|
+        next unless data.key?(key)
+
+        value = data[key]
+
+        # Check if this property has oneOf/anyOf/allOf
+        result[key] = if property_schema['oneOf'] || property_schema['anyOf'] || property_schema['allOf']
+                        coerce_with_one_of(value, property_schema)
+                      elsif property_schema['properties'] && value.is_a?(Hash)
+                        # Nested object - recurse
+                        coerce_types(value, property_schema)
+                      elsif property_schema['type'] == 'array' && value.is_a?(Array)
+                        # Array - coerce each item
+                        coerce_array(value, property_schema)
+                      elsif property_schema['type'] == 'array' && value.is_a?(Hash)
+                        # Single item that should be array (XML quirk from Hash.from_xml)
+                        [coerce_item(value, property_schema['items'])]
+                      else
+                        # Simple value - coerce based on type
+                        TypeCoercion.coerce_value(value, property_schema)
+                      end
+      end.merge(data.except(*schema['properties'].keys))
+    end
+
+    def coerce_with_one_of(value, schema)
+      schemas = schema['oneOf'] || schema['anyOf'] || schema['allOf']
+
+      # For Hash (single item), try the first schema (should be the object schema)
+      # For Array, try the second schema (should be the array schema)
+      case value
+      when Array
+        array_schema = schemas.find { |s| s['type'] == 'array' }
+        return coerce_array(value, array_schema) if array_schema
+      when Hash
+        object_schema = schemas.find { |s| s['type'] != 'array' }
+        # Need to resolve $ref here - for now just try to coerce
+        return coerce_item(value, object_schema) if object_schema
+      end
+
+      value
+    end
+
+    def coerce_array(array, schema)
+      return array unless schema['items']
+
+      array.map do |item|
+        coerce_item(item, schema['items'])
+      end
+    end
+
+    def coerce_item(item, schema)
+      if schema['properties'] && item.is_a?(Hash)
+        coerce_types(item, schema)
+      else
+        TypeCoercion.coerce_value(item, schema)
+      end
+    end
+  end
+end

--- a/lib/openapi_first/xml_coercion.rb
+++ b/lib/openapi_first/xml_coercion.rb
@@ -9,7 +9,7 @@ module OpenapiFirst
     def xml_content_type?(content_type)
       return false unless content_type
 
-      media_type = content_type.split(';').first.strip
+      media_type = content_type.split(';').first&.strip
       %w[application/xml text/xml].include?(media_type)
     end
 
@@ -40,7 +40,7 @@ module OpenapiFirst
       end.merge(data.except(*schema['properties'].keys))
     end
 
-    def coerce_with_one_of(value, schema)
+    private_class_method def coerce_with_one_of(value, schema)
       schemas = schema['oneOf'] || schema['anyOf'] || schema['allOf']
 
       # For Hash (single item), try the first schema (should be the object schema)
@@ -58,7 +58,7 @@ module OpenapiFirst
       value
     end
 
-    def coerce_array(array, schema)
+    private_class_method def coerce_array(array, schema)
       return array unless schema['items']
 
       array.map do |item|
@@ -66,7 +66,7 @@ module OpenapiFirst
       end
     end
 
-    def coerce_item(item, schema)
+    private_class_method def coerce_item(item, schema)
       if schema['properties'] && item.is_a?(Hash)
         coerce_types(item, schema)
       else

--- a/openapi_first.gemspec
+++ b/openapi_first.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = '>= 3.0.5'
 
+  spec.add_runtime_dependency 'activesupport', '>= 7.1'
   spec.add_runtime_dependency 'deep_merge', '>= 1.2.1'
   spec.add_runtime_dependency 'hanami-router', '~> 2.0.0'
   spec.add_runtime_dependency 'hanami-utils', '~> 2.0.0'

--- a/spec/data/petstore-xml.yaml
+++ b/spec/data/petstore-xml.yaml
@@ -81,6 +81,7 @@ components:
       required:
         - id
         - name
+        - status
       properties:
         id:
           type: string
@@ -90,6 +91,15 @@ components:
           type: string
           xml:
             name: name
+        status:
+          type: string
+          xml:
+            name: status
+            attribute: true
+          enum:
+            - available
+            - pending
+            - sold
         tag:
           type: string
           xml:

--- a/spec/data/petstore-xml.yaml
+++ b/spec/data/petstore-xml.yaml
@@ -1,0 +1,130 @@
+openapi: "3.0.0"
+info:
+  version: 1.0.0
+  title: Swagger Petstore XML
+  license:
+    name: MIT
+servers:
+  - url: http://petstore.swagger.io/v1
+paths:
+  /pets:
+    get:
+      summary: List all pets
+      operationId: listPets
+      tags:
+        - pets
+      responses:
+        '200':
+          description: An array of pets
+          content:
+            application/xml:
+              schema:
+                $ref: "#/components/schemas/PetsXml"
+        '400':
+          description: unexpected error
+          content:
+            application/xml:
+              schema:
+                $ref: "#/components/schemas/ErrorXml"
+    post:
+      summary: Create a pet
+      operationId: createPets
+      tags:
+        - pets
+      requestBody:
+        required: true
+        content:
+          application/xml:
+            schema:
+              $ref: "#/components/schemas/PetXml"
+      responses:
+        '201':
+          description: Null response
+        '400':
+          description: unexpected error
+          content:
+            application/xml:
+              schema:
+                $ref: "#/components/schemas/ErrorXml"
+  /pets/{petId}:
+    get:
+      summary: Info for a specific pet
+      operationId: showPetById
+      tags:
+        - pets
+      parameters:
+        - name: petId
+          in: path
+          required: true
+          description: The id of the pet to retrieve
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Expected response to a valid request
+          content:
+            application/xml:
+              schema:
+                $ref: "#/components/schemas/PetXml"
+        '400':
+          description: unexpected error
+          content:
+            application/xml:
+              schema:
+                $ref: "#/components/schemas/ErrorXml"
+components:
+  schemas:
+    PetXml:
+      type: object
+      xml:
+        name: pet
+      required:
+        - id
+        - name
+      properties:
+        id:
+          type: string
+          xml:
+            name: id
+        name:
+          type: string
+          xml:
+            name: name
+        tag:
+          type: string
+          xml:
+            name: tag
+    PetsXml:
+      type: object
+      properties:
+        pets:
+          type: object
+          xml:
+            name: pets
+          properties:
+            pet:
+              oneOf:
+                - $ref: "#/components/schemas/PetXml"
+                - type: array
+                  items:
+                    $ref: "#/components/schemas/PetXml"
+          required:
+            - pet
+      required:
+        - pets
+    ErrorXml:
+      type: object
+      xml:
+        name: error
+      required:
+        - code
+        - message
+      properties:
+        code:
+          type: string
+          xml:
+            name: code
+        message:
+          type: string
+          xml:
+            name: message

--- a/spec/data/petstore-xml.yaml
+++ b/spec/data/petstore-xml.yaml
@@ -36,7 +36,7 @@ paths:
         content:
           application/xml:
             schema:
-              $ref: "#/components/schemas/PetXml"
+              $ref: "#/components/schemas/PetRequest"
       responses:
         '201':
           description: Null response
@@ -74,6 +74,13 @@ paths:
                 $ref: "#/components/schemas/ErrorXml"
 components:
   schemas:
+    PetRequest:
+      type: object
+      properties:
+        pet:
+          $ref: '#/components/schemas/PetXml'
+      required:
+        - pet
     PetXml:
       type: object
       xml:
@@ -84,7 +91,7 @@ components:
         - status
       properties:
         id:
-          type: string
+          type: integer
           xml:
             name: id
         name:

--- a/spec/request_validation/request_body_validation_spec.rb
+++ b/spec/request_validation/request_body_validation_spec.rb
@@ -368,7 +368,7 @@ RSpec.describe 'Request body validation' do
         end
       end
 
-      it 'coerces XML string values to proper types' do
+      it 'coerces XML string element values to proper types' do
         xml_body = <<~XML
           <pet status="available">
             <id>42</id>
@@ -376,13 +376,26 @@ RSpec.describe 'Request body validation' do
           </pet>
         XML
 
-        header Rack::CONTENT_TYPE, 'application/xml'
-        post '/pets', xml_body
+        perform_pets_post_request(xml_body)
 
         expect(last_response.status).to eq(200), last_response.body
         parsed_response = json_load(last_response.body, symbolize_keys: true)
         expect(parsed_response[:pet][:id]).to eq(42)
         expect(parsed_response[:pet][:status]).to eq('available')
+      end
+
+      it 'coerces XML string attribute values to proper types' do
+        xml_body = <<~XML
+          <pet status="available" id="42">
+            <name>Fluffy</name>
+          </pet>
+        XML
+
+        perform_pets_post_request(xml_body)
+
+        expect(last_response.status).to eq(200), last_response.body
+        parsed_response = json_load(last_response.body, symbolize_keys: true)
+        expect(parsed_response[:pet][:id]).to eq(42)
       end
 
       it 'preserves additional properties not in schema' do
@@ -394,8 +407,7 @@ RSpec.describe 'Request body validation' do
           </pet>
         XML
 
-        header Rack::CONTENT_TYPE, 'application/xml'
-        post '/pets', xml_body
+        perform_pets_post_request(xml_body)
 
         expect(last_response.status).to eq(200), last_response.body
         parsed_response = json_load(last_response.body, symbolize_keys: true)
@@ -410,11 +422,15 @@ RSpec.describe 'Request body validation' do
           </pet>
         XML
 
-        header Rack::CONTENT_TYPE, 'application/xml'
-        post '/pets', xml_body
+        perform_pets_post_request(xml_body)
 
         # Should fail validation because 'not-a-number' can't be coerced to integer
         expect(last_response.status).to eq(400)
+      end
+
+      def perform_pets_post_request(xml_body)
+        header Rack::CONTENT_TYPE, 'application/xml'
+        post '/pets', xml_body
       end
     end
 

--- a/spec/request_validation/request_body_validation_spec.rb
+++ b/spec/request_validation/request_body_validation_spec.rb
@@ -355,31 +355,9 @@ RSpec.describe 'Request body validation' do
     end
 
     describe 'XML request body coercion' do
-      class XmlParserMiddleware # rubocop:disable Lint/ConstantDefinitionInBlock
-        def initialize(app)
-          @app = app
-        end
-
-        def call(env)
-          request = Rack::Request.new(env)
-          puts "Content-Type: #{request.content_type}"
-          puts "Body: #{request.body.read.inspect}"
-          request.body.rewind
-
-          if request.content_type&.include?('xml')
-            body = request.body.read
-            request.body.rewind
-            parsed = Hash.from_xml(body) if body.present?
-            env['router.parsed_body'] = parsed if parsed
-          end
-          @app.call(env)
-        end
-      end
-
       let(:app) do
         Rack::Builder.new do
           use OpenapiFirst::Router, spec: './spec/data/petstore-xml.yaml', raise_error: true
-          use XmlParserMiddleware
           use OpenapiFirst::RequestValidation
           run lambda { |env|
             # Convert the parsed/coerced request body back to JSON for test verification.

--- a/spec/request_validation/request_body_validation_spec.rb
+++ b/spec/request_validation/request_body_validation_spec.rb
@@ -303,7 +303,7 @@ RSpec.describe 'Request body validation' do
       end
     end
 
-    describe 'with a readOnly required field' do
+    describe 'with a required readOnly field' do
       let(:app) do
         Rack::Builder.new do
           use OpenapiFirst::Router, spec: './spec/data/readonly.yaml', raise_error: true
@@ -351,6 +351,92 @@ RSpec.describe 'Request body validation' do
         }
         post '/test', json_dump(request_body)
         expect(last_response.status).to eq 201
+      end
+    end
+
+    describe 'XML request body coercion' do
+      class XmlParserMiddleware # rubocop:disable Lint/ConstantDefinitionInBlock
+        def initialize(app)
+          @app = app
+        end
+
+        def call(env)
+          request = Rack::Request.new(env)
+          puts "Content-Type: #{request.content_type}"
+          puts "Body: #{request.body.read.inspect}"
+          request.body.rewind
+
+          if request.content_type&.include?('xml')
+            body = request.body.read
+            request.body.rewind
+            parsed = Hash.from_xml(body) if body.present?
+            env['router.parsed_body'] = parsed if parsed
+          end
+          @app.call(env)
+        end
+      end
+
+      let(:app) do
+        Rack::Builder.new do
+          use OpenapiFirst::Router, spec: './spec/data/petstore-xml.yaml', raise_error: true
+          use XmlParserMiddleware
+          use OpenapiFirst::RequestValidation
+          run lambda { |env|
+            # Convert the parsed/coerced request body back to JSON for test verification.
+            # This allows us to inspect that XML string values (e.g., "42") were properly
+            # coerced to their schema types (e.g., integer 42) during request validation.
+            [200, {}, [MultiJson.dump(env[OpenapiFirst::REQUEST_BODY])]]
+          }
+        end
+      end
+
+      it 'coerces XML string values to proper types' do
+        xml_body = <<~XML
+          <pet status="available">
+            <id>42</id>
+            <name>Fluffy</name>
+          </pet>
+        XML
+
+        header Rack::CONTENT_TYPE, 'application/xml'
+        post '/pets', xml_body
+
+        expect(last_response.status).to eq(200), last_response.body
+        parsed_response = json_load(last_response.body, symbolize_keys: true)
+        expect(parsed_response[:pet][:id]).to eq(42)
+        expect(parsed_response[:pet][:status]).to eq('available')
+      end
+
+      it 'preserves additional properties not in schema' do
+        xml_body = <<~XML
+          <pet status="available">
+            <id>42</id>
+            <name>Fluffy</name>
+            <extra>additional data</extra>
+          </pet>
+        XML
+
+        header Rack::CONTENT_TYPE, 'application/xml'
+        post '/pets', xml_body
+
+        expect(last_response.status).to eq(200), last_response.body
+        parsed_response = json_load(last_response.body, symbolize_keys: true)
+        expect(parsed_response[:pet][:extra]).to eq('additional data')
+      end
+
+      it 'validates coerced values against schema' do
+        xml_body = <<~XML
+          <pet status="available">
+            <id>not-a-number</id>
+            <name>Fluffy</name>
+          </pet>
+        XML
+
+        header Rack::CONTENT_TYPE, 'application/xml'
+        post '/pets', xml_body
+
+        # Should fail validation because 'not-a-number' can't be coerced to integer
+        expect(last_response.status).to eq(400)
       end
     end
 

--- a/spec/response_validator_spec.rb
+++ b/spec/response_validator_spec.rb
@@ -114,7 +114,7 @@ RSpec.describe OpenapiFirst::ResponseValidator do
     let(:xml_headers) { { Rack::CONTENT_TYPE => 'application/xml' } }
 
     let(:xml_request) do
-      env = Rack::MockRequest.env_for('/pets')
+      env = Rack::MockRequest.env_for('/pets', method: 'GET')
       Rack::Request.new(env)
     end
 

--- a/spec/response_validator_spec.rb
+++ b/spec/response_validator_spec.rb
@@ -25,25 +25,25 @@ RSpec.describe OpenapiFirst::ResponseValidator do
                                   { id: 2, name: 'Voldemort' }
                                 ])
       response = Rack::MockResponse.new(200, headers, response_body)
-      subject.validate(request, response)
+      expect { subject.validate(request, response) }.not_to raise_error
     end
 
     it 'falls back to the default' do
       response_body = JSON.dump(code: 422, message: 'Not good!')
       response = Rack::MockResponse.new(422, headers, response_body)
-      subject.validate(request, response)
+      expect { subject.validate(request, response) }.not_to raise_error
     end
 
     it 'returns no errors on additional, not required properties' do
       response_body = json_dump([{ id: 42, name: 'hans', something: 'else' }])
       response = Rack::MockResponse.new(200, headers, response_body)
-      subject.validate(request, response)
+      expect { subject.validate(request, response) }.not_to raise_error
     end
 
     it 'returns no errors if OAS file has no content' do
       expect_any_instance_of(OpenapiFirst::Operation).to receive(:response_for) { {} }
       response = Rack::MockResponse.new(200, headers, 'body')
-      subject.validate(request, response)
+      expect { subject.validate(request, response) }.not_to raise_error
     end
 
     it 'returns no errors if OAS file has no response_for schema specified' do
@@ -51,7 +51,7 @@ RSpec.describe OpenapiFirst::ResponseValidator do
       expect_any_instance_of(OpenapiFirst::Operation)
         .to receive(:response_for) { { 'content' => empty_content } }
       response = Rack::MockResponse.new(200, headers, 'body')
-      subject.validate(request, response)
+      expect { subject.validate(request, response) }.not_to raise_error
     end
   end
 
@@ -122,24 +122,24 @@ RSpec.describe OpenapiFirst::ResponseValidator do
       it 'validates valid XML response' do
         response_body = <<~XML
           <pets>
-            <pet>
+            <pet status="available">
               <id>42</id>
               <name>hans</name>
             </pet>
-            <pet>
+            <pet status="sold">
               <id>2</id>
               <name>Voldemort</name>
             </pet>
           </pets>
         XML
         response = Rack::MockResponse.new(200, xml_headers, response_body)
-        xml_validator.validate(xml_request, response)
+        expect { xml_validator.validate(xml_request, response) }.not_to raise_error
       end
 
       it 'accepts additional XML elements' do
         response_body = <<~XML
           <pets>
-            <pet>
+            <pet status="pending">
               <id>42</id>
               <name>hans</name>
               <tag>extra</tag>
@@ -147,7 +147,7 @@ RSpec.describe OpenapiFirst::ResponseValidator do
           </pets>
         XML
         response = Rack::MockResponse.new(200, xml_headers, response_body)
-        xml_validator.validate(xml_request, response)
+        expect { xml_validator.validate(xml_request, response) }.not_to raise_error
       end
     end
 
@@ -155,7 +155,7 @@ RSpec.describe OpenapiFirst::ResponseValidator do
       it 'fails on missing required XML elements' do
         response_body = <<~XML
           <pets>
-            <pet>
+            <pet status="available">
               <id>42</id>
             </pet>
           </pets>
@@ -169,13 +169,58 @@ RSpec.describe OpenapiFirst::ResponseValidator do
       it 'fails on unknown status code' do
         response_body = <<~XML
           <pets>
-            <pet>
+            <pet status="available">
               <id>42</id>
               <name>hans</name>
             </pet>
           </pets>
         XML
         response = Rack::MockResponse.new(204, xml_headers, response_body)
+        expect do
+          xml_validator.validate(xml_request, response)
+        end.to raise_error OpenapiFirst::ResponseInvalid
+      end
+    end
+
+    describe 'XML attribute validation' do
+      it 'validates XML attributes (status)' do
+        response_body = <<~XML
+          <pets>
+            <pet status="available">
+              <id>42</id>
+              <name>Fluffy</name>
+            </pet>
+          </pets>
+        XML
+        response = Rack::MockResponse.new(200, xml_headers, response_body)
+        expect { xml_validator.validate(xml_request, response) }.not_to raise_error
+      end
+
+      it 'fails when required attribute is missing' do
+        response_body = <<~XML
+          <pets>
+            <pet>
+              <id>42</id>
+              <name>Fluffy</name>
+            </pet>
+          </pets>
+        XML
+        response = Rack::MockResponse.new(200, xml_headers, response_body)
+        expect do
+          xml_validator.validate(xml_request, response)
+        end.to raise_error OpenapiFirst::ResponseInvalid
+      end
+
+      it 'fails when attribute has invalid enum value' do
+        response_body = <<~XML
+          <pets>
+            <pet status="reserved">
+              <id>42</id>
+              <name>Fluffy</name>
+            </pet>
+          </pets>
+        XML
+        response = Rack::MockResponse.new(200, xml_headers, response_body)
         expect do
           xml_validator.validate(xml_request, response)
         end.to raise_error OpenapiFirst::ResponseInvalid

--- a/spec/response_validator_spec.rb
+++ b/spec/response_validator_spec.rb
@@ -103,4 +103,83 @@ RSpec.describe OpenapiFirst::ResponseValidator do
       end.to raise_error OpenapiFirst::ResponseInvalid
     end
   end
+
+  describe 'XML response validation' do
+    let(:xml_spec) { './spec/data/petstore-xml.yaml' }
+
+    let(:xml_validator) do
+      described_class.new(xml_spec)
+    end
+
+    let(:xml_headers) { { Rack::CONTENT_TYPE => 'application/xml' } }
+
+    let(:xml_request) do
+      env = Rack::MockRequest.env_for('/pets')
+      Rack::Request.new(env)
+    end
+
+    describe 'valid XML response' do
+      it 'validates valid XML response' do
+        response_body = <<~XML
+          <pets>
+            <pet>
+              <id>42</id>
+              <name>hans</name>
+            </pet>
+            <pet>
+              <id>2</id>
+              <name>Voldemort</name>
+            </pet>
+          </pets>
+        XML
+        response = Rack::MockResponse.new(200, xml_headers, response_body)
+        xml_validator.validate(xml_request, response)
+      end
+
+      it 'accepts additional XML elements' do
+        response_body = <<~XML
+          <pets>
+            <pet>
+              <id>42</id>
+              <name>hans</name>
+              <tag>extra</tag>
+            </pet>
+          </pets>
+        XML
+        response = Rack::MockResponse.new(200, xml_headers, response_body)
+        xml_validator.validate(xml_request, response)
+      end
+    end
+
+    describe 'invalid XML response' do
+      it 'fails on missing required XML elements' do
+        response_body = <<~XML
+          <pets>
+            <pet>
+              <id>42</id>
+            </pet>
+          </pets>
+        XML
+        response = Rack::MockResponse.new(200, xml_headers, response_body)
+        expect do
+          xml_validator.validate(xml_request, response)
+        end.to raise_error OpenapiFirst::ResponseInvalid
+      end
+
+      it 'fails on unknown status code' do
+        response_body = <<~XML
+          <pets>
+            <pet>
+              <id>42</id>
+              <name>hans</name>
+            </pet>
+          </pets>
+        XML
+        response = Rack::MockResponse.new(204, xml_headers, response_body)
+        expect do
+          xml_validator.validate(xml_request, response)
+        end.to raise_error OpenapiFirst::ResponseInvalid
+      end
+    end
+  end
 end

--- a/spec/type_coercion_spec.rb
+++ b/spec/type_coercion_spec.rb
@@ -1,0 +1,149 @@
+# frozen_string_literal: true
+
+RSpec.describe OpenapiFirst::TypeCoercion do
+  describe '.coerce_value' do
+    context 'when schema type is boolean' do
+      let(:schema) { { 'type' => 'boolean' } }
+
+      it 'converts "true" string to true boolean' do
+        expect(described_class.coerce_value('true', schema)).to be true
+      end
+
+      it 'converts "false" string to false boolean' do
+        expect(described_class.coerce_value('false', schema)).to be false
+      end
+
+      it 'returns original value for non-boolean strings' do
+        expect(described_class.coerce_value('not_a_boolean', schema)).to eq('not_a_boolean')
+      end
+
+      it 'returns original value for nil' do
+        expect(described_class.coerce_value(nil, schema)).to be_nil
+      end
+    end
+
+    context 'when schema type is integer' do
+      let(:schema) { { 'type' => 'integer' } }
+
+      it 'converts valid integer string to integer' do
+        expect(described_class.coerce_value('42', schema)).to eq(42)
+      end
+
+      it 'converts negative integer string to integer' do
+        expect(described_class.coerce_value('-42', schema)).to eq(-42)
+      end
+
+      it 'converts zero string to integer' do
+        expect(described_class.coerce_value('0', schema)).to eq(0)
+      end
+
+      it 'returns original value for invalid integer strings' do
+        expect(described_class.coerce_value('not_an_integer', schema)).to eq('not_an_integer')
+      end
+
+      it 'returns original value for float strings' do
+        expect(described_class.coerce_value('42.5', schema)).to eq('42.5')
+      end
+
+      it 'returns original value for empty string' do
+        expect(described_class.coerce_value('', schema)).to eq('')
+      end
+
+      it 'returns original value when ArgumentError is raised' do
+        expect(described_class.coerce_value('12abc', schema)).to eq('12abc')
+      end
+    end
+
+    context 'when schema type is number' do
+      let(:schema) { { 'type' => 'number' } }
+
+      it 'converts valid float string to float' do
+        expect(described_class.coerce_value('42.5', schema)).to eq(42.5)
+      end
+
+      it 'converts integer string to float' do
+        expect(described_class.coerce_value('42', schema)).to eq(42.0)
+      end
+
+      it 'converts negative float string to float' do
+        expect(described_class.coerce_value('-42.5', schema)).to eq(-42.5)
+      end
+
+      it 'converts zero string to float' do
+        expect(described_class.coerce_value('0', schema)).to eq(0.0)
+      end
+
+      it 'returns original value for invalid number strings' do
+        expect(described_class.coerce_value('not_a_number', schema)).to eq('not_a_number')
+      end
+
+      it 'returns original value for empty string' do
+        expect(described_class.coerce_value('', schema)).to eq('')
+      end
+
+      it 'returns original value when ArgumentError is raised' do
+        expect(described_class.coerce_value('12.5abc', schema)).to eq('12.5abc')
+      end
+    end
+
+    context 'when schema type is string or other' do
+      let(:schema) { { 'type' => 'string' } }
+
+      it 'returns original value without coercion' do
+        expect(described_class.coerce_value('some_string', schema)).to eq('some_string')
+      end
+
+      it 'returns numeric string as-is' do
+        expect(described_class.coerce_value('123', schema)).to eq('123')
+      end
+    end
+
+    context 'when schema type is nil or missing' do
+      let(:schema) { {} }
+
+      it 'returns original value without coercion' do
+        expect(described_class.coerce_value('value', schema)).to eq('value')
+      end
+    end
+  end
+
+  describe '.to_boolean' do
+    it 'converts "true" string to true' do
+      expect(described_class.to_boolean('true')).to be true
+    end
+
+    it 'converts "false" string to false' do
+      expect(described_class.to_boolean('false')).to be false
+    end
+
+    it 'returns original value for "True" with capital T' do
+      expect(described_class.to_boolean('True')).to eq('True')
+    end
+
+    it 'returns original value for "FALSE" in uppercase' do
+      expect(described_class.to_boolean('FALSE')).to eq('FALSE')
+    end
+
+    it 'returns original value for non-boolean strings' do
+      expect(described_class.to_boolean('yes')).to eq('yes')
+    end
+
+    it 'returns original value for empty string' do
+      expect(described_class.to_boolean('')).to eq('')
+    end
+
+    it 'returns original value for nil' do
+      expect(described_class.to_boolean(nil)).to be_nil
+    end
+
+    it 'returns original value for numeric values' do
+      expect(described_class.to_boolean(1)).to eq(1)
+      expect(described_class.to_boolean(0)).to eq(0)
+    end
+
+    it 'returns original value for actual boolean values' do
+      expect(described_class.to_boolean(true)).to be true
+      expect(described_class.to_boolean(false)).to be false
+    end
+  end
+end

--- a/spec/type_coercion_spec.rb
+++ b/spec/type_coercion_spec.rb
@@ -20,6 +20,10 @@ RSpec.describe OpenapiFirst::TypeCoercion do
       it 'returns original value for nil' do
         expect(described_class.coerce_value(nil, schema)).to be_nil
       end
+
+      it 'returns original value for uppercase value' do
+        expect(described_class.coerce_value('FALSE', schema)).to eq('FALSE')
+      end
     end
 
     context 'when schema type is integer' do
@@ -104,46 +108,6 @@ RSpec.describe OpenapiFirst::TypeCoercion do
       it 'returns original value without coercion' do
         expect(described_class.coerce_value('value', schema)).to eq('value')
       end
-    end
-  end
-
-  describe '.to_boolean' do
-    it 'converts "true" string to true' do
-      expect(described_class.to_boolean('true')).to be true
-    end
-
-    it 'converts "false" string to false' do
-      expect(described_class.to_boolean('false')).to be false
-    end
-
-    it 'returns original value for "True" with capital T' do
-      expect(described_class.to_boolean('True')).to eq('True')
-    end
-
-    it 'returns original value for "FALSE" in uppercase' do
-      expect(described_class.to_boolean('FALSE')).to eq('FALSE')
-    end
-
-    it 'returns original value for non-boolean strings' do
-      expect(described_class.to_boolean('yes')).to eq('yes')
-    end
-
-    it 'returns original value for empty string' do
-      expect(described_class.to_boolean('')).to eq('')
-    end
-
-    it 'returns original value for nil' do
-      expect(described_class.to_boolean(nil)).to be_nil
-    end
-
-    it 'returns original value for numeric values' do
-      expect(described_class.to_boolean(1)).to eq(1)
-      expect(described_class.to_boolean(0)).to eq(0)
-    end
-
-    it 'returns original value for actual boolean values' do
-      expect(described_class.to_boolean(true)).to be true
-      expect(described_class.to_boolean(false)).to be false
     end
   end
 end

--- a/spec/xml_coercion_spec.rb
+++ b/spec/xml_coercion_spec.rb
@@ -1,0 +1,338 @@
+# frozen_string_literal: true
+
+RSpec.describe OpenapiFirst::XmlCoercion do
+  describe '.xml_content_type?' do
+    it 'returns true for application/xml' do
+      expect(described_class.xml_content_type?('application/xml')).to be true
+    end
+
+    it 'returns true for text/xml' do
+      expect(described_class.xml_content_type?('text/xml')).to be true
+    end
+
+    it 'returns true for application/xml with charset' do
+      expect(described_class.xml_content_type?('application/xml; charset=utf-8')).to be true
+    end
+
+    it 'returns true for text/xml with charset' do
+      expect(described_class.xml_content_type?('text/xml; charset=utf-8')).to be true
+    end
+
+    it 'returns false for application/json' do
+      expect(described_class.xml_content_type?('application/json')).to be false
+    end
+
+    it 'returns false for nil' do
+      expect(described_class.xml_content_type?(nil)).to be false
+    end
+
+    it 'returns false for empty string' do
+      expect(described_class.xml_content_type?('')).to be false
+    end
+
+    it 'returns false for text/html' do
+      expect(described_class.xml_content_type?('text/html')).to be false
+    end
+  end
+
+  describe '.coerce_types' do
+    context 'when schema has no properties' do
+      it 'returns data unchanged' do
+        data = { 'key' => 'value' }
+        schema = {}
+        expect(described_class.coerce_types(data, schema)).to eq(data)
+      end
+    end
+
+    context 'with simple type coercion' do
+      let(:schema) do
+        {
+          'properties' => {
+            'age' => { 'type' => 'integer' },
+            'price' => { 'type' => 'number' },
+            'active' => { 'type' => 'boolean' },
+            'name' => { 'type' => 'string' }
+          }
+        }
+      end
+
+      it 'coerces integer properties' do
+        data = { 'age' => '42', 'name' => 'John' }
+        result = described_class.coerce_types(data, schema)
+        expect(result['age']).to eq(42)
+      end
+
+      it 'coerces number properties' do
+        data = { 'price' => '19.99' }
+        result = described_class.coerce_types(data, schema)
+        expect(result['price']).to eq(19.99)
+      end
+
+      it 'coerces boolean properties' do
+        data = { 'active' => 'true' }
+        result = described_class.coerce_types(data, schema)
+        expect(result['active']).to be true
+      end
+
+      it 'preserves string properties' do
+        data = { 'name' => 'John' }
+        result = described_class.coerce_types(data, schema)
+        expect(result['name']).to eq('John')
+      end
+
+      it 'preserves keys not in schema' do
+        data = { 'age' => '42', 'unknown' => 'value' }
+        result = described_class.coerce_types(data, schema)
+        expect(result['unknown']).to eq('value')
+      end
+
+      it 'only processes keys present in data' do
+        data = { 'age' => '42' }
+        result = described_class.coerce_types(data, schema)
+        expect(result).not_to have_key('price')
+      end
+    end
+
+    context 'with nested objects' do
+      let(:schema) do
+        {
+          'properties' => {
+            'user' => {
+              'type' => 'object',
+              'properties' => {
+                'age' => { 'type' => 'integer' },
+                'name' => { 'type' => 'string' }
+              }
+            }
+          }
+        }
+      end
+
+      it 'recursively coerces nested object properties' do
+        data = { 'user' => { 'age' => '30', 'name' => 'Alice' } }
+        result = described_class.coerce_types(data, schema)
+        expect(result['user']['age']).to eq(30)
+        expect(result['user']['name']).to eq('Alice')
+      end
+
+      it 'does not coerce nested objects when value is not a hash' do
+        data = { 'user' => 'not_a_hash' }
+        result = described_class.coerce_types(data, schema)
+        expect(result['user']).to eq('not_a_hash')
+      end
+    end
+
+    context 'with arrays' do
+      let(:schema) do
+        {
+          'properties' => {
+            'ids' => {
+              'type' => 'array',
+              'items' => { 'type' => 'integer' }
+            }
+          }
+        }
+      end
+
+      it 'coerces array items' do
+        data = { 'ids' => %w[1 2 3] }
+        result = described_class.coerce_types(data, schema)
+        expect(result['ids']).to eq([1, 2, 3])
+      end
+
+      it 'handles empty arrays' do
+        data = { 'ids' => [] }
+        result = described_class.coerce_types(data, schema)
+        expect(result['ids']).to eq([])
+      end
+    end
+
+    context 'with XML quirk - single item as hash instead of array' do
+      let(:schema) do
+        {
+          'properties' => {
+            'items' => {
+              'type' => 'array',
+              'items' => {
+                'type' => 'object',
+                'properties' => {
+                  'id' => { 'type' => 'integer' }
+                }
+              }
+            }
+          }
+        }
+      end
+
+      it 'converts single hash to array with coerced item' do
+        data = { 'items' => { 'id' => '123' } }
+        result = described_class.coerce_types(data, schema)
+        expect(result['items']).to be_an(Array)
+        expect(result['items'].size).to eq(1)
+        expect(result['items'][0]['id']).to eq(123)
+      end
+    end
+
+    context 'with arrays of objects' do
+      let(:schema) do
+        {
+          'properties' => {
+            'users' => {
+              'type' => 'array',
+              'items' => {
+                'type' => 'object',
+                'properties' => {
+                  'age' => { 'type' => 'integer' },
+                  'active' => { 'type' => 'boolean' }
+                }
+              }
+            }
+          }
+        }
+      end
+
+      it 'coerces properties in array items' do
+        data = { 'users' => [{ 'age' => '25', 'active' => 'true' }, { 'age' => '30', 'active' => 'false' }] }
+        result = described_class.coerce_types(data, schema)
+        expect(result['users'][0]['age']).to eq(25)
+        expect(result['users'][0]['active']).to be true
+        expect(result['users'][1]['age']).to eq(30)
+        expect(result['users'][1]['active']).to be false
+      end
+    end
+
+    context 'with oneOf schema' do
+      let(:schema) do
+        {
+          'properties' => {
+            'data' => {
+              'oneOf' => [
+                {
+                  'type' => 'object',
+                  'properties' => { 'id' => { 'type' => 'integer' } }
+                },
+                {
+                  'type' => 'array',
+                  'items' => {
+                    'type' => 'object',
+                    'properties' => { 'id' => { 'type' => 'integer' } }
+                  }
+                }
+              ]
+            }
+          }
+        }
+      end
+
+      it 'coerces hash value using object schema' do
+        data = { 'data' => { 'id' => '42' } }
+        result = described_class.coerce_types(data, schema)
+        expect(result['data']['id']).to eq(42)
+      end
+
+      it 'coerces array value using array schema' do
+        data = { 'data' => [{ 'id' => '1' }, { 'id' => '2' }] }
+        result = described_class.coerce_types(data, schema)
+        expect(result['data'][0]['id']).to eq(1)
+        expect(result['data'][1]['id']).to eq(2)
+      end
+    end
+
+    context 'with anyOf schema' do
+      let(:schema) do
+        {
+          'properties' => {
+            'value' => {
+              'anyOf' => [
+                { 'type' => 'object', 'properties' => { 'count' => { 'type' => 'integer' } } },
+                { 'type' => 'array', 'items' => { 'type' => 'integer' } }
+              ]
+            }
+          }
+        }
+      end
+
+      it 'coerces hash value' do
+        data = { 'value' => { 'count' => '10' } }
+        result = described_class.coerce_types(data, schema)
+        expect(result['value']['count']).to eq(10)
+      end
+
+      it 'coerces array value' do
+        data = { 'value' => %w[5 10] }
+        result = described_class.coerce_types(data, schema)
+        expect(result['value']).to eq([5, 10])
+      end
+    end
+
+    context 'with allOf schema' do
+      let(:schema) do
+        {
+          'properties' => {
+            'item' => {
+              'allOf' => [
+                { 'type' => 'object', 'properties' => { 'num' => { 'type' => 'integer' } } },
+                { 'type' => 'array', 'items' => { 'type' => 'integer' } }
+              ]
+            }
+          }
+        }
+      end
+
+      it 'handles hash value' do
+        data = { 'item' => { 'num' => '99' } }
+        result = described_class.coerce_types(data, schema)
+        expect(result['item']['num']).to eq(99)
+      end
+
+      it 'handles array value' do
+        data = { 'item' => %w[7 8] }
+        result = described_class.coerce_types(data, schema)
+        expect(result['item']).to eq([7, 8])
+      end
+    end
+
+    context 'with complex nested structures' do
+      let(:schema) do
+        {
+          'properties' => {
+            'company' => {
+              'type' => 'object',
+              'properties' => {
+                'name' => { 'type' => 'string' },
+                'employees' => {
+                  'type' => 'array',
+                  'items' => {
+                    'type' => 'object',
+                    'properties' => {
+                      'id' => { 'type' => 'integer' },
+                      'active' => { 'type' => 'boolean' }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      end
+
+      it 'coerces deeply nested structures' do
+        data = {
+          'company' => {
+            'name' => 'Acme',
+            'employees' => [
+              { 'id' => '1', 'active' => 'true' },
+              { 'id' => '2', 'active' => 'false' }
+            ]
+          }
+        }
+        result = described_class.coerce_types(data, schema)
+        expect(result['company']['name']).to eq('Acme')
+        expect(result['company']['employees'][0]['id']).to eq(1)
+        expect(result['company']['employees'][0]['active']).to be true
+        expect(result['company']['employees'][1]['id']).to eq(2)
+        expect(result['company']['employees'][1]['active']).to be false
+      end
+    end
+  end
+end

--- a/spec/xml_coercion_spec.rb
+++ b/spec/xml_coercion_spec.rb
@@ -266,29 +266,105 @@ RSpec.describe OpenapiFirst::XmlCoercion do
     end
 
     context 'with allOf schema' do
+      # allOf means the value must satisfy ALL schemas simultaneously
+      # This is typically used to combine properties from multiple schemas
       let(:schema) do
         {
           'properties' => {
-            'item' => {
+            'user' => {
               'allOf' => [
-                { 'type' => 'object', 'properties' => { 'num' => { 'type' => 'integer' } } },
-                { 'type' => 'array', 'items' => { 'type' => 'integer' } }
+                {
+                  'type' => 'object',
+                  'properties' => {
+                    'id' => { 'type' => 'integer' },
+                    'name' => { 'type' => 'string' }
+                  }
+                },
+                {
+                  'type' => 'object',
+                  'properties' => {
+                    'active' => { 'type' => 'boolean' },
+                    'age' => { 'type' => 'integer' }
+                  }
+                }
               ]
             }
           }
         }
       end
 
-      it 'handles hash value' do
-        data = { 'item' => { 'num' => '99' } }
+      it 'merges properties from all schemas and coerces them' do
+        data = {
+          'user' => {
+            'id' => '123',
+            'name' => 'Alice',
+            'active' => 'true',
+            'age' => '30'
+          }
+        }
         result = described_class.coerce_types(data, schema)
-        expect(result['item']['num']).to eq(99)
+
+        # All properties from both schemas should be coerced
+        expect(result['user']['id']).to eq(123)
+        expect(result['user']['name']).to eq('Alice')
+        expect(result['user']['active']).to be true
+        expect(result['user']['age']).to eq(30)
       end
 
-      it 'handles array value' do
-        data = { 'item' => %w[7 8] }
+      it 'handles partial data with properties from first schema' do
+        data = { 'user' => { 'id' => '99', 'name' => 'Bob' } }
         result = described_class.coerce_types(data, schema)
-        expect(result['item']).to eq([7, 8])
+
+        expect(result['user']['id']).to eq(99)
+        expect(result['user']['name']).to eq('Bob')
+      end
+
+      it 'handles partial data with properties from second schema' do
+        data = { 'user' => { 'active' => 'false', 'age' => '25' } }
+        result = described_class.coerce_types(data, schema)
+
+        expect(result['user']['active']).to be false
+        expect(result['user']['age']).to eq(25)
+      end
+
+      context 'with three schemas in allOf' do
+        let(:schema) do
+          {
+            'properties' => {
+              'product' => {
+                'allOf' => [
+                  {
+                    'type' => 'object',
+                    'properties' => { 'id' => { 'type' => 'integer' } }
+                  },
+                  {
+                    'type' => 'object',
+                    'properties' => { 'price' => { 'type' => 'number' } }
+                  },
+                  {
+                    'type' => 'object',
+                    'properties' => { 'inStock' => { 'type' => 'boolean' } }
+                  }
+                ]
+              }
+            }
+          }
+        end
+
+        it 'merges properties from all three schemas' do
+          data = {
+            'product' => {
+              'id' => '456',
+              'price' => '29.99',
+              'inStock' => 'true'
+            }
+          }
+          result = described_class.coerce_types(data, schema)
+
+          expect(result['product']['id']).to eq(456)
+          expect(result['product']['price']).to eq(29.99)
+          expect(result['product']['inStock']).to be true
+        end
       end
     end
 


### PR DESCRIPTION
## Add XML response validation support

### Motivation
As of now the response validator can work only with JSON. With the addition of the SIRI-SM version of the bus stop timetables endpoint it is necessary to validate also XML content.

### Changes
Extends the response validator to support XML content validation in addition to the existing JSON validation.

part of: https://kanbanzone.io/b/YA2t2Uox/c/1493-Design-and-implement-MVP-of-NextBuses-compatible-stop-timetables-endpoint