### PR TITLE
Use type coercion for form encoded request/response bodies and plain text response validation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,10 +11,10 @@ Metrics/BlockLength:
     - "spec/**/*.rb"
     - "*.gemspec"
 Metrics/MethodLength:
-  Max: 20
+  Max: 50
 
 Metrics/AbcSize:
-  Max: 30
+  Max: 35
 
 Metrics/CyclomaticComplexity:
   Max: 13

--- a/lib/openapi_first/body_parser_middleware.rb
+++ b/lib/openapi_first/body_parser_middleware.rb
@@ -4,7 +4,7 @@ require 'active_support/isolated_execution_state'
 require 'active_support/xml_mini'
 require 'active_support/core_ext/hash/conversions'
 require 'multi_json'
-require_relative 'xml_coercion'
+require_relative 'content_type'
 
 module OpenapiFirst
   class BodyParserMiddleware
@@ -41,7 +41,7 @@ module OpenapiFirst
       return if body.empty?
 
       return MultiJson.load(body) if request.media_type =~ (/json/i) && (request.media_type =~ /json/i)
-      return Hash.from_xml(body) if XmlCoercion.xml_content_type?(request.content_type)
+      return Hash.from_xml(body) if ContentType.xml?(request.content_type)
       return request.POST if request.form_data?
 
       body

--- a/lib/openapi_first/content_type.rb
+++ b/lib/openapi_first/content_type.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module OpenapiFirst
+  module ContentType
+    module_function
+
+    def json?(content_type)
+      return false unless content_type
+
+      media_type = content_type.split(';').first&.strip
+      media_type == 'application/json'
+    end
+
+    def xml?(content_type)
+      return false unless content_type
+
+      media_type = content_type.split(';').first&.strip
+      %w[application/xml text/xml].include?(media_type)
+    end
+
+    def form_encoded?(content_type)
+      return false unless content_type
+
+      media_type = content_type.split(';').first&.strip
+      media_type == 'application/x-www-form-urlencoded'
+    end
+
+    def plain_text?(content_type)
+      return false unless content_type
+
+      media_type = content_type.split(';').first&.strip
+      media_type == 'text/plain'
+    end
+  end
+end

--- a/lib/openapi_first/request_validation.rb
+++ b/lib/openapi_first/request_validation.rb
@@ -5,7 +5,7 @@ require 'multi_json'
 require_relative 'inbox'
 require_relative 'use_router'
 require_relative 'validation_format'
-require_relative 'xml_coercion'
+require_relative 'string_based_coercion'
 require_relative 'type_coercion'
 
 module OpenapiFirst
@@ -58,8 +58,8 @@ module OpenapiFirst
       return unless schema
 
       # Convert XML string values to proper types based on schema
-      if XmlCoercion.xml_content_type?(request.content_type) && body.is_a?(Hash)
-        body = XmlCoercion.coerce_types(body, schema.raw_schema)
+      if StringBasedCoercion.coercible_content_type?(request.content_type) && body.is_a?(Hash)
+        body = StringBasedCoercion.coerce_types(body, schema.raw_schema)
       end
 
       errors = schema.validate(body)

--- a/lib/openapi_first/response_validation.rb
+++ b/lib/openapi_first/response_validation.rb
@@ -7,7 +7,8 @@ require 'multi_json'
 require 'rj_schema'
 require_relative 'use_router'
 require_relative 'validation_format'
-require_relative 'xml_coercion'
+require_relative 'string_based_coercion'
+require_relative 'content_type'
 
 module OpenapiFirst
   class ResponseValidation
@@ -44,11 +45,17 @@ module OpenapiFirst
     def validate_response_body(schema, response, content_type)
       full_body = +''
       response.each { |chunk| full_body << chunk }
+
+      if ContentType.plain_text?(content_type)
+        validate_plain_text(full_body, schema)
+        return
+      end
+
       data = if full_body.empty?
                {}
-             elsif XmlCoercion.xml_content_type?(content_type)
-               parsed = Hash.from_xml(full_body)
-               XmlCoercion.coerce_types(parsed, schema.raw_schema)
+             elsif StringBasedCoercion.coercible_content_type?(content_type)
+               parsed = ContentType.xml?(content_type) ? Hash.from_xml(full_body) : full_body
+               StringBasedCoercion.coerce_types(parsed, schema.raw_schema)
              else
                load_json(full_body)
              end
@@ -70,6 +77,36 @@ module OpenapiFirst
       MultiJson.load(string)
     rescue MultiJson::ParseError
       string
+    end
+
+    def validate_plain_text(body, schema)
+      raw = schema.raw_schema
+      body = body.strip
+
+      if raw['type'] && raw['type'] != 'string'
+        raise ::OpenapiFirst::ResponseBodyInvalidError,
+              "Expected type '#{raw['type']}' but got a plain text response"
+      end
+
+      if raw['enum'] && !raw['enum'].include?(body)
+        raise ::OpenapiFirst::ResponseBodyInvalidError,
+              "Response body '#{body}' is not one of: #{raw['enum'].join(', ')}"
+      end
+
+      if raw['minLength'] && body.length < raw['minLength']
+        raise ::OpenapiFirst::ResponseBodyInvalidError,
+              "Response body is shorter than minLength: #{raw['minLength']}"
+      end
+
+      if raw['maxLength'] && body.length > raw['maxLength']
+        raise ::OpenapiFirst::ResponseBodyInvalidError,
+              "Response body is longer than maxLength: #{raw['maxLength']}"
+      end
+
+      if raw['pattern'] && !body.match?(Regexp.new(raw['pattern'])) # rubocop:disable Style/GuardClause
+        raise ::OpenapiFirst::ResponseBodyInvalidError,
+              "Response body does not match pattern: #{raw['pattern']}"
+      end
     end
   end
 end

--- a/lib/openapi_first/string_based_coercion.rb
+++ b/lib/openapi_first/string_based_coercion.rb
@@ -3,14 +3,11 @@
 require_relative 'type_coercion'
 
 module OpenapiFirst
-  module XmlCoercion
+  module StringBasedCoercion
     module_function
 
-    def xml_content_type?(content_type)
-      return false unless content_type
-
-      media_type = content_type.split(';').first&.strip
-      %w[application/xml text/xml].include?(media_type)
+    def coercible_content_type?(content_type)
+      ContentType.xml?(content_type) || ContentType.form_encoded?(content_type)
     end
 
     def coerce_types(data, schema)

--- a/lib/openapi_first/validation_format.rb
+++ b/lib/openapi_first/validation_format.rb
@@ -4,8 +4,6 @@ module OpenapiFirst
   module ValidationFormat
     SIMPLE_TYPES = %w[string integer].freeze
 
-    # rubocop:disable Metrics/MethodLength
-    # rubocop:disable Metrics/AbcSize
     def self.error_details(error)
       if error['type'] == 'pattern'
         {
@@ -45,7 +43,5 @@ module OpenapiFirst
         { title: "is not valid: #{error['data'].inspect}" }
       end
     end
-    # rubocop:enable Metrics/MethodLength
-    # rubocop:enable Metrics/AbcSize
   end
 end

--- a/spec/content_type_spec.rb
+++ b/spec/content_type_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+RSpec.describe OpenapiFirst::ContentType do
+  describe '.json?' do
+    it 'returns true for application/json' do
+      expect(described_class.json?('application/json')).to be true
+    end
+
+    it 'returns true for application/json with charset' do
+      expect(described_class.json?('application/json; charset=utf-8')).to be true
+    end
+
+    it 'returns false for application/xml' do
+      expect(described_class.json?('application/xml')).to be false
+    end
+
+    it 'returns false for nil' do
+      expect(described_class.json?(nil)).to be false
+    end
+  end
+
+  describe '.xml?' do
+    it 'returns true for application/xml' do
+      expect(described_class.xml?('application/xml')).to be true
+    end
+
+    it 'returns true for text/xml' do
+      expect(described_class.xml?('text/xml')).to be true
+    end
+
+    it 'returns true for application/xml with charset' do
+      expect(described_class.xml?('application/xml; charset=utf-8')).to be true
+    end
+
+    it 'returns false for application/json' do
+      expect(described_class.xml?('application/json')).to be false
+    end
+
+    it 'returns false for nil' do
+      expect(described_class.xml?(nil)).to be false
+    end
+  end
+
+  describe '.form_encoded?' do
+    it 'returns true for application/x-www-form-urlencoded' do
+      expect(described_class.form_encoded?('application/x-www-form-urlencoded')).to be true
+    end
+
+    it 'returns true for application/x-www-form-urlencoded with charset' do
+      expect(described_class.form_encoded?('application/x-www-form-urlencoded; charset=utf-8')).to be true
+    end
+
+    it 'returns false for application/json' do
+      expect(described_class.form_encoded?('application/json')).to be false
+    end
+
+    it 'returns false for nil' do
+      expect(described_class.form_encoded?(nil)).to be false
+    end
+  end
+
+  describe '.plain_text?' do
+    it 'returns true for text/plain' do
+      expect(described_class.plain_text?('text/plain')).to be true
+    end
+
+    it 'returns true for text/plain with charset' do
+      expect(described_class.plain_text?('text/plain; charset=utf-8')).to be true
+    end
+
+    it 'returns false for application/json' do
+      expect(described_class.plain_text?('application/json')).to be false
+    end
+
+    it 'returns false for nil' do
+      expect(described_class.plain_text?(nil)).to be false
+    end
+  end
+end

--- a/spec/data/plain-text-constrained.yaml
+++ b/spec/data/plain-text-constrained.yaml
@@ -1,0 +1,18 @@
+openapi: 3.0.3
+info:
+  title: Plain text constrained test
+  version: '1.0'
+paths:
+  /status:
+    get:
+      operationId: getStatus
+      responses:
+        '200':
+          description: A status code
+          content:
+            text/plain:
+              schema:
+                type: string
+                minLength: 3
+                maxLength: 10
+                pattern: '^[A-Z]+$'

--- a/spec/data/plain-text-response.yaml
+++ b/spec/data/plain-text-response.yaml
@@ -1,0 +1,27 @@
+openapi: 3.0.3
+info:
+  title: Plain text test
+  version: '1.0'
+paths:
+  /sms/inbound:
+    post:
+      operationId: receiveInboundSms
+      requestBody:
+        required: true
+        content:
+          application/x-www-form-urlencoded:
+            schema:
+              type: object
+              properties:
+                Content:
+                  type: string
+      responses:
+        '200':
+          description: Accepted or rejected
+          content:
+            text/plain:
+              schema:
+                type: string
+                enum:
+                  - Success
+                  - Fail

--- a/spec/response_validator_spec.rb
+++ b/spec/response_validator_spec.rb
@@ -227,4 +227,98 @@ RSpec.describe OpenapiFirst::ResponseValidator do
       end
     end
   end
+
+  describe 'Plain text response with enum validation' do
+    let(:plain_text_spec) { './spec/data/plain-text-response.yaml' }
+    let(:plain_text_validator) { described_class.new(plain_text_spec) }
+    let(:plain_text_headers) { { Rack::CONTENT_TYPE => 'text/plain' } }
+
+    let(:plain_text_request) do
+      env = Rack::MockRequest.env_for('/sms/inbound', method: 'POST')
+      Rack::Request.new(env)
+    end
+
+    describe 'valid plain text response' do
+      it 'accepts Success' do
+        response = Rack::MockResponse.new(200, plain_text_headers, 'Success')
+        expect { plain_text_validator.validate(plain_text_request, response) }.not_to raise_error
+      end
+
+      it 'accepts Fail' do
+        response = Rack::MockResponse.new(200, plain_text_headers, 'Fail')
+        expect { plain_text_validator.validate(plain_text_request, response) }.not_to raise_error
+      end
+    end
+
+    describe 'invalid plain text response' do
+      it 'fails when body is not in the enum' do
+        response = Rack::MockResponse.new(200, plain_text_headers, 'Invalid')
+        expect do
+          plain_text_validator.validate(plain_text_request, response)
+        end.to raise_error OpenapiFirst::ResponseInvalid
+      end
+
+      it 'fails when body is empty' do
+        response = Rack::MockResponse.new(200, plain_text_headers, '')
+        expect do
+          plain_text_validator.validate(plain_text_request, response)
+        end.to raise_error OpenapiFirst::ResponseInvalid
+      end
+    end
+  end
+
+  # Add alongside the other plain text tests in response_validator_spec.rb
+  # Fixture file: spec/data/plain-text-constrained.yaml
+
+  describe 'Plain text response with length and pattern constraints' do
+    let(:constrained_spec) { './spec/data/plain-text-constrained.yaml' }
+    let(:constrained_validator) { described_class.new(constrained_spec) }
+    let(:plain_text_headers) { { Rack::CONTENT_TYPE => 'text/plain' } }
+
+    let(:constrained_request) do
+      env = Rack::MockRequest.env_for('/status', method: 'GET')
+      Rack::Request.new(env)
+    end
+
+    describe 'valid response' do
+      it 'accepts a value that meets all constraints' do
+        response = Rack::MockResponse.new(200, plain_text_headers, 'ACTIVE')
+        expect { constrained_validator.validate(constrained_request, response) }.not_to raise_error
+      end
+    end
+
+    describe 'minLength violation' do
+      it 'fails when body is too short' do
+        response = Rack::MockResponse.new(200, plain_text_headers, 'OK')
+        expect do
+          constrained_validator.validate(constrained_request, response)
+        end.to raise_error OpenapiFirst::ResponseInvalid
+      end
+    end
+
+    describe 'maxLength violation' do
+      it 'fails when body is too long' do
+        response = Rack::MockResponse.new(200, plain_text_headers, 'UNAVAILABLE')
+        expect do
+          constrained_validator.validate(constrained_request, response)
+        end.to raise_error OpenapiFirst::ResponseInvalid
+      end
+    end
+
+    describe 'pattern violation' do
+      it 'fails when body contains lowercase characters' do
+        response = Rack::MockResponse.new(200, plain_text_headers, 'Active')
+        expect do
+          constrained_validator.validate(constrained_request, response)
+        end.to raise_error OpenapiFirst::ResponseInvalid
+      end
+
+      it 'fails when body contains digits' do
+        response = Rack::MockResponse.new(200, plain_text_headers, 'ABC123')
+        expect do
+          constrained_validator.validate(constrained_request, response)
+        end.to raise_error OpenapiFirst::ResponseInvalid
+      end
+    end
+  end
 end

--- a/spec/string_based_coercion_spec.rb
+++ b/spec/string_based_coercion_spec.rb
@@ -1,37 +1,25 @@
 # frozen_string_literal: true
 
-RSpec.describe OpenapiFirst::XmlCoercion do
-  describe '.xml_content_type?' do
+RSpec.describe OpenapiFirst::StringBasedCoercion do
+  describe '.coercible_content_type?' do
     it 'returns true for application/xml' do
-      expect(described_class.xml_content_type?('application/xml')).to be true
+      expect(described_class.coercible_content_type?('application/xml')).to be true
     end
 
     it 'returns true for text/xml' do
-      expect(described_class.xml_content_type?('text/xml')).to be true
+      expect(described_class.coercible_content_type?('text/xml')).to be true
     end
 
-    it 'returns true for application/xml with charset' do
-      expect(described_class.xml_content_type?('application/xml; charset=utf-8')).to be true
-    end
-
-    it 'returns true for text/xml with charset' do
-      expect(described_class.xml_content_type?('text/xml; charset=utf-8')).to be true
+    it 'returns true for application/x-www-form-urlencoded' do
+      expect(described_class.coercible_content_type?('application/x-www-form-urlencoded')).to be true
     end
 
     it 'returns false for application/json' do
-      expect(described_class.xml_content_type?('application/json')).to be false
+      expect(described_class.coercible_content_type?('application/json')).to be false
     end
 
     it 'returns false for nil' do
-      expect(described_class.xml_content_type?(nil)).to be false
-    end
-
-    it 'returns false for empty string' do
-      expect(described_class.xml_content_type?('')).to be false
-    end
-
-    it 'returns false for text/html' do
-      expect(described_class.xml_content_type?('text/html')).to be false
+      expect(described_class.coercible_content_type?(nil)).to be false
     end
   end
 


### PR DESCRIPTION
Integrating with DMB system requires new endpoints that has to process form encoded parameters and return plain text bodies.
This PR add request/response validation for this use case.

https://kanbanzone.io/b/YA2t2Uox/c/1538-Implement-stop-timetables-delivery-via-Traveline-SMS-premium-number